### PR TITLE
Added ability to store integer code in TraceableError to implement Coded Error

### DIFF
--- a/errs.go
+++ b/errs.go
@@ -6,13 +6,21 @@ import (
 	"strings"
 )
 
+type CodedError interface {
+	error
+	GetCode() int
+	SetCode(int)
+}
+
 type TraceableError interface {
+	CodedError
 	GetTrace() string
 	GetAllStackFrames() []string
 }
 
 type traceableError struct {
 	err   error
+	code  int
 	frame string
 }
 
@@ -21,6 +29,19 @@ func (trErr *traceableError) Error() string {
 		return trErr.err.Error()
 	}
 	return "unknown (unspecified) error"
+}
+
+func (trErr *traceableError) GetCode() int {
+	if trErr.code == 0 {
+		if err, ok := trErr.err.(CodedError); ok {
+			return err.GetCode()
+		}
+	}
+	return trErr.code
+}
+
+func (trErr *traceableError) SetCode(code int) {
+	trErr.code = code
 }
 
 func (trErr *traceableError) GetTrace() string {

--- a/interface.go
+++ b/interface.go
@@ -150,7 +150,7 @@ func (l *logger) LogFatal(err error, s ...string) {
 	exit(1)
 }
 
-func Trace(err error) error {
+func Trace(err error) TraceableError {
 	if err == nil {
 		return nil
 	}

--- a/logging_test.go
+++ b/logging_test.go
@@ -53,7 +53,12 @@ func TestNewFromConfig(t *testing.T) {
 
 	cfg.Direction = "stdout"
 	l = NewFromConfig(cfg)
-	assert.Equal(t, os.Stdout, l.w)
+	assert.Equal(t, os.Stdout, l.GetWriter())
+
+	cfg.EnableShortCaller = true
+	l = NewFromConfig(cfg)
+	l.UnsetFlags(Caller)
+	assert.Equal(t, Date|Time|ShortCaller|Labels, l.flag)
 }
 
 func TestNewFromConfig_CustomFileOutput(t *testing.T) {
@@ -237,18 +242,29 @@ func TestTrace(t *testing.T) {
 	tracedErr := Trace(err)
 	assert.NotEqual(t, nil, tracedErr)
 	assert.Equal(t, msg, tracedErr.Error())
+	assert.Equal(t, 0, tracedErr.GetCode())
+	assert.Implements(t, (*TraceableError)(nil), tracedErr)
+	assert.Equal(t, 2, len(tracedErr.GetAllStackFrames()))
 
-	traceableErr, ok := tracedErr.(TraceableError)
-	assert.True(t, ok)
-	assert.Equal(t, 2, len(traceableErr.GetAllStackFrames()))
+	tracedErr = Trace(tracedErr)
+	tracedErr.SetCode(500)
+	assert.Implements(t, (*TraceableError)(nil), tracedErr)
+	assert.Equal(t, msg, tracedErr.Error())
+	assert.Equal(t, 500, tracedErr.GetCode())
 
-	tracedTracedErr := Trace(tracedErr)
-	assert.NotEqual(t, nil, tracedTracedErr)
-	assert.Equal(t, msg, tracedTracedErr.Error())
+	tracedErr = Trace(tracedErr)
+	tracedErr.SetCode(600)
 
-	traceableErr, ok = tracedTracedErr.(TraceableError)
-	assert.True(t, ok)
-	assert.Equal(t, 3, len(traceableErr.GetAllStackFrames()))
+	assert.Equal(t, 4, len(tracedErr.GetAllStackFrames()))
+	assert.Equal(t, 600, tracedErr.GetCode())
+
+	// test recursion to get the first underlying error
+	trErr := Trace(fmt.Errorf(""))
+	trErr.SetCode(10)
+	trErr2 := Trace(trErr)
+	trErr3 := Trace(trErr2)
+	trErr4 := Trace(trErr3)
+	assert.Equal(t, 10, trErr4.GetCode())
 }
 
 func TestLogError(t *testing.T) {


### PR DESCRIPTION
- added ability to store integer code in TraceableError to implement Coded Error

- update unit tests to coverage this changes

https://sandsiv.atlassian.net/browse/VOC-11738